### PR TITLE
feat: Implement frontend and backend for Mock API server

### DIFF
--- a/backend/app/mock_storage.py
+++ b/backend/app/mock_storage.py
@@ -1,0 +1,52 @@
+import json
+import os
+from pathlib import Path
+from typing import List, Dict, Any
+
+# Resolve DATA_DIR relative to this file, assuming the structure is backend/app/mock_storage.py
+# and data/ is at the project root.
+try:
+    # This will work when running from the backend/ directory or project root.
+    ROOT_DIR = Path(__file__).resolve().parent.parent.parent
+except NameError:
+    # Fallback for environments where __file__ is not defined (e.g. some interactive shells)
+    ROOT_DIR = Path(os.getcwd())
+
+DATA_DIR = os.getenv("DATA_DIR", ROOT_DIR / "data")
+MOCKS_FILE = Path(DATA_DIR) / "mocks.json"
+
+def get_all_mocks() -> List[Dict[str, Any]]:
+    """
+    Reads all mock configurations from the JSON file.
+    """
+    if not MOCKS_FILE.exists():
+        return []
+    try:
+        with open(MOCKS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return []
+
+def save_mock(mock_config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Adds a new mock configuration to the list and saves it.
+    """
+    all_mocks = get_all_mocks()
+    # Assign a new ID
+    new_id = max([m.get('id', 0) for m in all_mocks] + [0]) + 1
+    mock_config['id'] = new_id
+    all_mocks.append(mock_config)
+
+    # Ensure the directory exists
+    MOCKS_FILE.parent.mkdir(exist_ok=True)
+    with open(MOCKS_FILE, "w", encoding="utf-8") as f:
+        json.dump(all_mocks, f, ensure_ascii=False, indent=2)
+
+    return mock_config
+
+def clear_all_mocks():
+    """
+    Deletes all mock configurations.
+    """
+    if MOCKS_FILE.exists():
+        os.remove(MOCKS_FILE)

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -33,6 +33,21 @@ async def delete_project(project_id: int):
             r.raise_for_status()
         return True
 
+# ---- Mock API ----
+async def get_mocks():
+    """Fetches the list of all active mock configurations."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.get(f"{base_url()}/api/mocks")
+        r.raise_for_status()
+        return r.json()
+
+async def create_mock(config: dict):
+    """Sends a new mock configuration to the backend."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        r = await client.post(f"{base_url()}/api/mock", json=config)
+        r.raise_for_status()
+        return r.json()
+
 # ---- Case Names ----
 async def list_web_case_names(project_id: int):
     async with httpx.AsyncClient(timeout=10.0) as client:


### PR DESCRIPTION
This commit introduces a new Mock API server feature.

Backend:
- Adds a new set of API endpoints (`/api/mock`, `/api/mocks`) to create and list mock configurations.
- Implements a catch-all route that intercepts requests and matches them against stored mock definitions (path, method, params, headers, body).
- If a match is found, it returns the configured response, including status, headers, body, and delay.
- Stores mock configurations in a new `data/mocks.json` file, managed by `mock_storage.py`.

Frontend:
- Adds a new 'Mock API' page to the NiceGUI frontend.
- The page displays a list of active mocks.
- Provides a comprehensive form for creating new mocks with sections for 'Request Matching' and 'Response Definition'.
- The form includes dynamic key-value inputs for query parameters and headers.
- Form submission is handled asynchronously without page reloads.